### PR TITLE
Update Statsbomb careers link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Some documentation about the meaning of different events and the format of the J
 
 ## Careers
 
-If you're interested in football data, [StatsBomb is always hiring!](https://statsbomb.bamboohr.com/jobs/)
+If you're interested in football data, [StatsBomb is always hiring!](https://statsbomb.com/careers/)


### PR DESCRIPTION
The link is now updated. Earlier, it redirected to BambooHR login page, now it redirects to the Statsbomb career page.