### PR TITLE
docs: update careers link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Some documentation about the meaning of different events and the format of the J
 
 ## Careers
 
-If you're interested in football data, [StatsBomb is always hiring!](https://statsbomb.bamboohr.com/jobs/)
+If you're interested in football data, [StatsBomb is always hiring!](https://www.hudl.com/jobs/search)


### PR DESCRIPTION
## Summary

- update the README careers link from the stale BambooHR URL to Hudl's public job search page

Closes #55

## Verification

- `git diff --check`
- `curl -L -I -s https://www.hudl.com/jobs/search` returned HTTP 200
